### PR TITLE
Updates to DaprVehicleStateRepository

### DIFF
--- a/src/TrafficControlService/Repositories/DaprVehicleStateRepository.cs
+++ b/src/TrafficControlService/Repositories/DaprVehicleStateRepository.cs
@@ -13,18 +13,17 @@ namespace TrafficControlService.Repositories
         {
             _daprClient = daprClient;
         }
-        public async Task<VehicleState> GetVehicleStateAsync(string licenseNumber)
-        {
-            var stateEntry = await _daprClient.GetStateEntryAsync<VehicleState>(
-                DAPR_STORE_NAME, licenseNumber);
-                
-            return stateEntry.Value;
-        }
 
         public async Task SaveVehicleStateAsync(VehicleState vehicleState)
         {
             await _daprClient.SaveStateAsync<VehicleState>(
                 DAPR_STORE_NAME, vehicleState.LicenseNumber, vehicleState);
+        }
+
+        public async Task<VehicleState> GetVehicleStateAsync(string licenseNumber)
+        {
+            return await _daprClient.GetStateAsync<VehicleState>(
+                DAPR_STORE_NAME, licenseNumber);
         }
     }
 }


### PR DESCRIPTION
- Use `GetState` instead of `GetStateEntry`. No use calling `GetStateEntry` if we only need to return the state value.
- Swap the order of the methods. Makes it a little bit easier to follow from the book, because I'm first explaining how save works.