### PR TITLE
Update start-mosquitto.ps1

### DIFF
--- a/src/Infrastructure/mosquitto/start-mosquitto.ps1
+++ b/src/Infrastructure/mosquitto/start-mosquitto.ps1
@@ -2,4 +2,4 @@
 # contains the custom configuration file we need for Dapr traffic-control (see mosquitto.conf).
 
 docker build -t dapr-trafficcontrol/mosquitto:1.0 .
-docker run -d -p 1883:1883 -p 9001:9001 --name dtc-mosquitto dapr-trafficcontrol/mosquitto
+docker run -d -p 1883:1883 -p 9001:9001 --name dtc-mosquitto dapr-trafficcontrol/mosquitto:1.0


### PR DESCRIPTION
Without the label it wants to use a "latest" from a repository that doesn't exist