### PR TITLE
Improvements

### DIFF
--- a/src/FineCollectionService/Controllers/CollectionController.cs
+++ b/src/FineCollectionService/Controllers/CollectionController.cs
@@ -20,8 +20,7 @@ public class CollectionController : ControllerBase
         // set finecalculator component license-key
         if (_fineCalculatorLicenseKey == null)
         {
-            bool useKubernetesSecrets
-             = Convert.ToBoolean(Environment.GetEnvironmentVariable("USE_KUBERNETES_SECRETS") ?? "false");
+            bool useKubernetesSecrets = Convert.ToBoolean(Environment.GetEnvironmentVariable("USE_KUBERNETES_SECRETS") ?? "false");
             string secretName = Environment.GetEnvironmentVariable("FINE_CALCULATOR_LICENSE_SECRET_NAME") ?? "finecalculator.licensekey";
             var metadata = new Dictionary<string, string> { { "namespace", "dapr-trafficcontrol" } };
             if (useKubernetesSecrets

--- a/src/FineCollectionService/Controllers/CollectionController.cs
+++ b/src/FineCollectionService/Controllers/CollectionController.cs
@@ -20,10 +20,12 @@ public class CollectionController : ControllerBase
         // set finecalculator component license-key
         if (_fineCalculatorLicenseKey == null)
         {
-            bool runningInK8s = Convert.ToBoolean(Environment.GetEnvironmentVariable("USE_KUBERNETES_SECRETS") ?? "false");
+            bool useKubernetesSecrets
+             = Convert.ToBoolean(Environment.GetEnvironmentVariable("USE_KUBERNETES_SECRETS") ?? "false");
             string secretName = Environment.GetEnvironmentVariable("FINE_CALCULATOR_LICENSE_SECRET_NAME") ?? "finecalculator.licensekey";
             var metadata = new Dictionary<string, string> { { "namespace", "dapr-trafficcontrol" } };
-            if (runningInK8s)
+            if (useKubernetesSecrets
+            )
             {
                 var k8sSecrets = daprClient.GetSecretAsync(
                     "kubernetes", "trafficcontrol-secrets", metadata).Result;

--- a/src/FineCollectionService/Controllers/CollectionController.cs
+++ b/src/FineCollectionService/Controllers/CollectionController.cs
@@ -1,4 +1,4 @@
-namespace FineCollectionService.Controllers;
+﻿namespace FineCollectionService.Controllers;
 
 [ApiController]
 [Route("")]
@@ -21,18 +21,19 @@ public class CollectionController : ControllerBase
         if (_fineCalculatorLicenseKey == null)
         {
             bool runningInK8s = Convert.ToBoolean(Environment.GetEnvironmentVariable("USE_KUBERNETES_SECRETS") ?? "false");
+            string secretName = Environment.GetEnvironmentVariable("FINE_CALCULATOR_LICENSE_SECRET_NAME") ?? "finecalculator.licensekey";
             var metadata = new Dictionary<string, string> { { "namespace", "dapr-trafficcontrol" } };
             if (runningInK8s)
             {
                 var k8sSecrets = daprClient.GetSecretAsync(
                     "kubernetes", "trafficcontrol-secrets", metadata).Result;
-                _fineCalculatorLicenseKey = k8sSecrets["finecalculator.licensekey"];
+                _fineCalculatorLicenseKey = k8sSecrets[secretName];
             }
             else
             {
                 var secrets = daprClient.GetSecretAsync(
-                    "trafficcontrol-secrets", "finecalculator.licensekey", metadata).Result;
-                _fineCalculatorLicenseKey = secrets["finecalculator.licensekey"];
+                    "trafficcontrol-secrets", secretName, metadata).Result;
+                _fineCalculatorLicenseKey = secrets[secretName];
             }
         }
     }

--- a/src/FineCollectionService/Controllers/CollectionController.cs
+++ b/src/FineCollectionService/Controllers/CollectionController.cs
@@ -23,8 +23,7 @@ public class CollectionController : ControllerBase
             bool useKubernetesSecrets = Convert.ToBoolean(Environment.GetEnvironmentVariable("USE_KUBERNETES_SECRETS") ?? "false");
             string secretName = Environment.GetEnvironmentVariable("FINE_CALCULATOR_LICENSE_SECRET_NAME") ?? "finecalculator.licensekey";
             var metadata = new Dictionary<string, string> { { "namespace", "dapr-trafficcontrol" } };
-            if (useKubernetesSecrets
-            )
+            if (useKubernetesSecrets)
             {
                 var k8sSecrets = daprClient.GetSecretAsync(
                     "kubernetes", "trafficcontrol-secrets", metadata).Result;

--- a/src/FineCollectionService/Controllers/CollectionController.cs
+++ b/src/FineCollectionService/Controllers/CollectionController.cs
@@ -1,4 +1,4 @@
-﻿namespace FineCollectionService.Controllers;
+namespace FineCollectionService.Controllers;
 
 [ApiController]
 [Route("")]
@@ -20,7 +20,7 @@ public class CollectionController : ControllerBase
         // set finecalculator component license-key
         if (_fineCalculatorLicenseKey == null)
         {
-            bool runningInK8s = Convert.ToBoolean(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER") ?? "false");
+            bool runningInK8s = Convert.ToBoolean(Environment.GetEnvironmentVariable("USE_KUBERNETES_SECRETS") ?? "false");
             var metadata = new Dictionary<string, string> { { "namespace", "dapr-trafficcontrol" } };
             if (runningInK8s)
             {

--- a/src/k8s/build-docker-images.ps1
+++ b/src/k8s/build-docker-images.ps1
@@ -1,5 +1,7 @@
-docker build -t dapr-trafficcontrol/mosquitto:1.0 ./mosquitto
-docker build -t dapr-trafficcontrol/trafficcontrolservice:1.0 ../trafficcontrolservice
-docker build -t dapr-trafficcontrol/finecollectionservice:1.0 ../finecollectionservice
-docker build -t dapr-trafficcontrol/vehicleregistrationservice:1.0 ../vehicleregistrationservice
-docker build -t dapr-trafficcontrol/simulation:1.0 ../simulation
+$path = $MyInvocation.MyCommand.Path | Split-Path
+
+& docker build --tag dapr-trafficcontrol/mosquitto:1.0 "$path/mosquitto"
+& docker build --tag dapr-trafficcontrol/trafficcontrolservice:1.0 "$path/../trafficcontrolservice"
+& docker build --tag dapr-trafficcontrol/finecollectionservice:1.0 "$path/../finecollectionservice"
+& docker build --tag dapr-trafficcontrol/vehicleregistrationservice:1.0 "$path/../vehicleregistrationservice"
+& docker build --tag dapr-trafficcontrol/simulation:1.0 "$path/../simulation"

--- a/src/k8s/finecollectionservice.yaml
+++ b/src/k8s/finecollectionservice.yaml
@@ -25,4 +25,7 @@ spec:
         image: dapr-trafficcontrol/finecollectionservice:1.0
         ports:
         - containerPort: 6001
+        env:
+          - name: USE_KUBERNETES_SECRETS
+            value: "true"
 


### PR DESCRIPTION
3 improvements, put them in separate commits if modification is required.

1. 303ac68 Environment key is now explicit mentioning Kubernetes secrets.
   Although using `DOTNET_RUNNING_IN_CONTAINER` to detect Kubernetes was a nice hack, Kubernetes is not the only time the application can run in a Docker environment. When using Azure Container Apps, Kubernetes secrets are not available and "regular" secrets should be used. 

2. fb241f3 Make license key secret name overridable
    Some secret stores, like Azure Key Vault, do not support `.` in the name of the key. Therefore, made it overridable. If no alternate name is provided via the `FINE_CALCULATOR_LICENSE_SECRET_NAME` environment key, the existing name will be used.

3. a3d28ac Allow script to be invoked from a different path
    Currently, you have to navigate into the `/src/k8s/` folder to be able to build the containers using the `build-docker-images.ps1` script. This will fail the script is called from any other location.
    By looking at the location of the script, the paths used will be always relative to the script, not the calling location.
    Just a little developer comfort.