### PR TITLE
update dockerfiles to use dotnet/sdk:8.0

### DIFF
--- a/src/FineCollectionService/Dockerfile
+++ b/src/FineCollectionService/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim-amd64 AS build-env
 WORKDIR /app
 
 # Copy necessary files and restore as distinct layer

--- a/src/Simulation/Dockerfile
+++ b/src/Simulation/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim-amd64 AS build-env
 WORKDIR /app
 
 # Copy necessary files and restore as distinct layer

--- a/src/TrafficControlService/Dockerfile
+++ b/src/TrafficControlService/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim-amd64 AS build-env
 WORKDIR /app
 
 # Copy necessary files and restore as distinct layer

--- a/src/VehicleRegistrationService/Dockerfile
+++ b/src/VehicleRegistrationService/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim-amd64 AS build-env
 WORKDIR /app
 
 # Copy necessary files and restore as distinct layer


### PR DESCRIPTION
update docker files to use dotnet 8.
New image base is mcr.microsoft.com/dotnet/sdk:8.0-bookworm-slim-amd64

fixes EdwinVW/dapr-traffic-control#32